### PR TITLE
build(deps): add prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,34 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# vercel
+.vercel

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "@chakra-ui/react": "^1.6.5",
         "@emotion/react": "^11.4.0",
@@ -27,7 +27,8 @@
         "eslint": "7.32.0",
         "eslint-config-next": "11.0.1",
         "eslint-config-prettier": "^8.3.0",
-        "next-sitemap": "^1.6.162"
+        "next-sitemap": "^1.6.162",
+        "prettier": "^2.3.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -6568,6 +6569,18 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/process": {
@@ -13347,6 +13360,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
       "dev": true
     },
     "process": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint": "7.32.0",
     "eslint-config-next": "11.0.1",
     "eslint-config-prettier": "^8.3.0",
-    "next-sitemap": "^1.6.162"
+    "next-sitemap": "^1.6.162",
+    "prettier": "^2.3.2"
   }
 }


### PR DESCRIPTION
Install an exact version of Prettier locally in the project. This makes sure that everyone in the project gets the exact same version of Prettier. Even a patch release of Prettier can result in slightly different formatting, so we wouldn’t want different team members using different versions and formatting each other’s changes back and forth.